### PR TITLE
fix for navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ const App = () => {
   const [view, setView] = useState('home');
 
   const navigate = (goto) => {
+    window.scrollTo(0, 0);
     setView(goto);
   };
 


### PR DESCRIPTION
When clicking navigation the page should scroll to the top for not confusing the user.